### PR TITLE
modal z-index changed to 6

### DIFF
--- a/src/components/InfiniteGallery.js
+++ b/src/components/InfiniteGallery.js
@@ -16,7 +16,7 @@ const Wrapper = styled.div`
 `;
 
 const customStyles = {
-  overlay: { zIndex: 2 },
+  overlay: { zIndex: 6 },
 };
 
 Modal.setAppElement("#modal");


### PR DESCRIPTION
solved: zoom control hide behind the app bar when light box open on index page. 